### PR TITLE
fix: readme - make links clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ Installation
 Documentation
 -----------------
 When you start your local server with `npm start` you can reach documentation.
-- `http://localhost:8080/api-docs` - Swagger documentation
-- `http://localhost:8080/v3/api-docs` - Open API JSON Docs
+- [Swagger documentation](http://localhost:8080/api-docs)
+- [Open API JSON Docs](http://localhost:8080/v3/api-docs)
+


### PR DESCRIPTION
just a small change for convenience so that I don't have to copy-paste links into the browser, I can just click on them